### PR TITLE
Mention Nix Package Manager in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ few tools if you don't already have them:
 - C++ compiler
 - `docker`
 - `ffmpeg`
+- [Nix Package Manager](https://nixos.org/download)
 
 ## Target Dependency Graph
 


### PR DESCRIPTION
`bazel build //...` fails without Nix Package Manager installed. Adding it to the list of tools required to work on this project