### PR TITLE
Generate entrypoint.sh via repository rule

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,6 +1,7 @@
 workspace(name = "bazel-community-day-workshop")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//bazel:defs.bzl", "generate_entrypoint")
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
@@ -13,7 +14,7 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_depende
 
 rules_nixpkgs_dependencies()
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_local_repository", "nixpkgs_cc_configure")
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure", "nixpkgs_local_repository")
 
 nixpkgs_local_repository(
     name = "nixpkgs",
@@ -47,7 +48,6 @@ http_archive(
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_repository(
@@ -88,9 +88,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 new_git_repository(
     name = "darkhttpd",
+    build_file_content = """exports_files(["darkhttpd.c"])""",
     commit = "11d36de0a2c94f21270877a7f6ea0050f4b9a346",
     remote = "https://github.com/emikulic/darkhttpd.git",
-    build_file_content = """exports_files(["darkhttpd.c"])""",
 )
 
 http_archive(
@@ -125,13 +125,17 @@ oci_pull(
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
     ],
-    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
+
+generate_entrypoint(
+    name = "docker_entrypoint",
+)

--- a/bazel/BUILD.bazel.tpl
+++ b/bazel/BUILD.bazel.tpl
@@ -1,0 +1,7 @@
+filegroup(
+    name = "entrypoint",
+    srcs = [
+        "entrypoint.sh",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -1,0 +1,25 @@
+def _generate_entrypoint_impl(repository_ctx):
+    """
+    Generate entrypoint.sh script for the docker image
+    to inject build version and date.
+    """
+    repository_ctx.report_progress("Generating entrypoint.sh...")
+    build_datetime = repository_ctx.execute(["date"]).stdout
+    repository_ctx.template(
+        "entrypoint.sh",
+        Label("//bazel:entrypoint.sh.tpl"),
+        {
+            "%{DATETIME}%": build_datetime,
+        },
+    )
+
+    repository_ctx.template(
+        "BUILD.bazel",
+        Label("//bazel:BUILD.bazel.tpl"),
+        {},
+    )
+
+generate_entrypoint = repository_rule(
+    implementation = _generate_entrypoint_impl,
+    local = True,
+)

--- a/bazel/entrypoint.sh.tpl
+++ b/bazel/entrypoint.sh.tpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+# BUILD DATETIME: %{DATETIME}%
 set -eu
 
 printf "\n\x1b[1;37mhttp://localhost:8080/animated.gif\x1b[0m\n\n"

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 genrule(
     name = "overlay",
     srcs = [
-        ":entrypoint.sh",
+        "@docker_entrypoint//:entrypoint",
         "//gif:animated",
     ],
     outs = ["overlay.tar"],


### PR DESCRIPTION
Introduce a simple repository rule that keeps generating entrypoint.sh over and over again preventing cache hit.

Misc: also used buildifier to slightly reformat WORKSPACE and all newly introduced files in bazel/ folder